### PR TITLE
Place shader uniforms outside uniform blocks (#1066)

### DIFF
--- a/common/src/main/java/com/graphicsfuzz/common/util/PipelineInfo.java
+++ b/common/src/main/java/com/graphicsfuzz/common/util/PipelineInfo.java
@@ -269,26 +269,6 @@ public final class PipelineInfo {
     return dictionary.getAsJsonObject(uniformName).get("args").getAsJsonArray().size() - 1;
   }
 
-  /**
-   * Returns the next unused binding number.
-   * @return The next unused binding number.
-   */
-  public int getUnusedBindingNumber() {
-    List<Integer> bindings =
-        dictionary.entrySet().stream()
-            .filter(item -> item.getValue().getAsJsonObject().has("binding"))
-            .map(item -> item.getValue().getAsJsonObject()
-            .get("binding").getAsInt()).collect(Collectors.toList());
-
-    for (int number = 0; number < Integer.MAX_VALUE; number++) {
-      if (!bindings.contains(number)) {
-        return number;
-      }
-    }
-
-    throw new RuntimeException("Unreachable code. MAX_VALUE should never been used in bindings.");
-  }
-
   public List<String> getUniformNames() {
     return dictionary.entrySet()
         .stream()
@@ -402,6 +382,45 @@ public final class PipelineInfo {
     gridDimensions.add("dimensions", dimensions);
     dictionary.add(Constants.GRID_DATA_KEY, gridDimensions);
   }
+
+  /**
+   * Returns the next unused binding number.
+   * @return The next unused binding number.
+   */
+  public int getUnusedBindingNumber() {
+    List<Integer> bindings =
+        dictionary.entrySet().stream()
+            .filter(item -> item.getValue().getAsJsonObject().has("binding"))
+            .map(item -> item.getValue().getAsJsonObject()
+                .get("binding").getAsInt()).collect(Collectors.toList());
+
+    for (int number = 0; number < Integer.MAX_VALUE; number++) {
+      if (!bindings.contains(number)) {
+        return number;
+      }
+    }
+
+    throw new RuntimeException("Unreachable code. MAX_VALUE should never been used in bindings.");
+  }
+
+  public void addSamplerInfo(String name, String samplerType, String textureName) {
+    assert isLegalUniformName(name);
+    if (dictionary.has(name)) {
+      if (!((JsonObject)dictionary.get(name)).get("func").getAsString().equals(samplerType)) {
+        // A variable of this name already exists, but has different type
+        throw new RuntimeException("Sampler redefined as a different type");
+      }
+      // If name and type matches, we don't need to do anything.
+    } else {
+      // Add sampler to dictionary
+      // "foo": { "func": "sampler2D", "texture": "SOME_STRING" }
+      JsonObject info = new JsonObject();
+      info.addProperty("func", samplerType);
+      info.addProperty("texture", textureName);
+      dictionary.add(name, info);
+    }
+  }
+
 
   private JsonObject lookupUniform(String uniformName) {
     assert isLegalUniformName(uniformName);

--- a/common/src/test/java/com/graphicsfuzz/common/transformreduce/GlslShaderJobTest.java
+++ b/common/src/test/java/com/graphicsfuzz/common/transformreduce/GlslShaderJobTest.java
@@ -530,6 +530,134 @@ public class GlslShaderJobTest {
 
   }
 
+  private static final String VERT_SHADER_WITH_SAMPLERS_NO_BINDINGS = ""
+      + "uniform float a;"
+      + "uniform sampler2D vtex;"
+      + "uniform float b;"
+      + "void main() { }";
+
+  private static final String FRAG_SHADER_WITH_SAMPLERS_NO_BINDINGS = ""
+      + "uniform float b;"
+      + "uniform sampler3D ftex;"
+      + "uniform float f[2];"
+      + "void main() { }";
+
+  private static final String JSON_WITH_SAMPLERS_NO_BINDINGS = "{"
+      + "  \"a\": {"
+      + "    \"args\": ["
+      + "      1.0"
+      + "    ], "
+      + "    \"func\": \"glUniform1f\""
+      + "  }, "
+      + "  \"b\": {"
+      + "    \"args\": ["
+      + "      0.0"
+      + "    ], "
+      + "    \"func\": \"glUniform1f\""
+      + "  }, "
+      + "  \"f\": {"
+      + "    \"args\": ["
+      + "      100.0, 50.0"
+      + "    ], "
+      + "    \"func\": \"glUniform1f\""
+      + "  },"
+      + "  \"vtex\": {"
+      + "    \"func\": \"sampler2D\","
+      + "    \"texture\": \"DEFAULT\""
+      + "  },"
+      + "  \"ftex\": {"
+      + "    \"func\": \"sampler3D\","
+      + "    \"texture\": \"DEFAULT\""
+      + "  }"
+      + "}";
+
+  private static final String VERT_SHADER_WITH_SAMPLERS_WITH_BINDINGS = ""
+      + "layout(set = 0, binding = 0) uniform buf0 { float a; };"
+      + "layout(set = 0, binding = 1) uniform sampler2D vtex;"
+      + "layout(set = 0, binding = 2) uniform buf2 { float b; };"
+      + "void main() { }";
+
+  private static final String FRAG_SHADER_WITH_SAMPLERS_WITH_BINDINGS = ""
+      + "layout(set = 0, binding = 2) uniform buf2 { float b; };"
+      + "layout(set = 0, binding = 3) uniform sampler3D ftex;"
+      + "layout(set = 0, binding = 4) uniform buf4 { float f[2]; };"
+      + "void main() { }";
+
+  private static final String JSON_WITH_SAMPLERS_WITH_BINDINGS = "{"
+      + "  \"a\": {"
+      + "    \"args\": ["
+      + "      1.0"
+      + "    ], "
+      + "    \"func\": \"glUniform1f\", "
+      + "    \"binding\": 0"
+      + "  }, "
+      + "  \"b\": {"
+      + "    \"args\": ["
+      + "      0.0"
+      + "    ], "
+      + "    \"func\": \"glUniform1f\", "
+      + "    \"binding\": 2"
+      + "  }, "
+      + "  \"f\": {"
+      + "    \"args\": ["
+      + "      100.0, 50.0"
+      + "    ], "
+      + "    \"func\": \"glUniform1f\", "
+      + "    \"binding\": 4"
+      + "  },"
+      + "  \"vtex\": {"
+      + "    \"func\": \"sampler2D\","
+      + "    \"texture\": \"DEFAULT\","
+      + "    \"binding\": 1"
+      + "  },"
+      + "  \"ftex\": {"
+      + "    \"func\": \"sampler3D\","
+      + "    \"texture\": \"DEFAULT\","
+      + "    \"binding\": 3"
+      + "  }"
+      + "}";
+
+
+  @Test
+  public void testMakeUniformBindingsWithSamplers() throws Exception {
+
+    final GlslShaderJob job = new GlslShaderJob(
+        Optional.empty(),
+        new PipelineInfo(JSON_WITH_SAMPLERS_NO_BINDINGS),
+        ParseHelper.parse(getShaderFile("vert", VERT_SHADER_WITH_SAMPLERS_NO_BINDINGS)),
+        ParseHelper.parse(getShaderFile("frag", FRAG_SHADER_WITH_SAMPLERS_NO_BINDINGS)));
+
+    job.makeUniformBindings(Optional.empty());
+
+    CompareAsts.assertEqualAsts(VERT_SHADER_WITH_SAMPLERS_WITH_BINDINGS,
+        job.getVertexShader().get());
+    CompareAsts.assertEqualAsts(FRAG_SHADER_WITH_SAMPLERS_WITH_BINDINGS,
+        job.getFragmentShader().get());
+    assertEquals(new PipelineInfo(JSON_WITH_SAMPLERS_WITH_BINDINGS).toString(),
+        job.getPipelineInfo().toString());
+  }
+
+  @Test
+  public void testRemoveUniformBindingsWithSamplers() throws Exception {
+
+    final GlslShaderJob job = new GlslShaderJob(
+        Optional.empty(),
+        new PipelineInfo(JSON_WITH_SAMPLERS_WITH_BINDINGS),
+        ParseHelper.parse(getShaderFile("vert", VERT_SHADER_WITH_SAMPLERS_WITH_BINDINGS)),
+        ParseHelper.parse(getShaderFile("frag", FRAG_SHADER_WITH_SAMPLERS_WITH_BINDINGS)));
+
+    job.removeUniformBindings();
+
+    CompareAsts.assertEqualAsts(VERT_SHADER_WITH_SAMPLERS_NO_BINDINGS,
+        job.getVertexShader().get());
+    CompareAsts.assertEqualAsts(FRAG_SHADER_WITH_SAMPLERS_NO_BINDINGS,
+        job.getFragmentShader().get());
+    assertEquals(new PipelineInfo(JSON_WITH_SAMPLERS_NO_BINDINGS).toString(),
+        job.getPipelineInfo().toString());
+
+  }
+
+
   private File getShaderFile(String extension, String content) throws IOException {
     final File file = temporaryFolder.newFile("shader." + extension);
     FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);


### PR DESCRIPTION
Added code to allow for sampler uniforms. In Vulkan,
all uniforms must be in uniform blocks, except for
samplers, which may not be in uniform blocks.

This affects both the code that adds uniform blocks
and the code that removes them.